### PR TITLE
MG1 — Service map config + prefer-local-fallback-remote routing core

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/src/Andy.Mcp.Gateway/Andy.Mcp.Gateway.csproj
+++ b/src/Andy.Mcp.Gateway/Andy.Mcp.Gateway.csproj
@@ -12,6 +12,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="YamlDotNet" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="servicemap.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Mcp.Gateway/Controllers/RoutingController.cs
+++ b/src/Andy.Mcp.Gateway/Controllers/RoutingController.cs
@@ -1,0 +1,81 @@
+using Andy.Mcp.Gateway.Models;
+using Andy.Mcp.Gateway.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Mcp.Gateway.Controllers;
+
+/// <summary>
+/// Read-only diagnostic surface over the gateway's service map and routing
+/// decisions. Operators (and Conductor's LocalRuntime UI) can inspect what
+/// the gateway thinks the world looks like.
+/// </summary>
+[ApiController]
+[Route("api/routing")]
+[Produces("application/json")]
+public sealed class RoutingController : ControllerBase
+{
+    private readonly IServiceMapRegistry _registry;
+    private readonly IServiceRouter _router;
+    private readonly IRouteHealthMonitor _health;
+
+    public RoutingController(
+        IServiceMapRegistry registry,
+        IServiceRouter router,
+        IRouteHealthMonitor health)
+    {
+        _registry = registry;
+        _router = router;
+        _health = health;
+    }
+
+    /// <summary>
+    /// List every service in the map plus its current health.
+    /// </summary>
+    [HttpGet("services")]
+    [ProducesResponseType(typeof(IEnumerable<ServiceMapView>), StatusCodes.Status200OK)]
+    public IActionResult ListServices()
+    {
+        var view = _registry.Entries
+            .Select(e => new ServiceMapView(
+                ServiceId: e.ServiceId,
+                LocalUrl: e.LocalUrl,
+                RemoteUrlPattern: e.RemoteUrlPattern,
+                RequiresAuth: e.RequiresAuth,
+                LocalHealthy: !string.IsNullOrEmpty(e.LocalUrl) && _health.IsLocalHealthy(e.ServiceId)));
+        return Ok(view);
+    }
+
+    /// <summary>
+    /// Resolve a single service id — same call the gateway internals make
+    /// when forwarding a request. Useful for debugging routing decisions.
+    /// </summary>
+    [HttpGet("resolve/{serviceId}")]
+    [ProducesResponseType(typeof(ResolvedRoute), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> Resolve(string serviceId, CancellationToken ct)
+    {
+        try
+        {
+            var route = await _router.ResolveAsync(serviceId, ct);
+            return Ok(route);
+        }
+        catch (ServiceNotInMapException)
+        {
+            return NotFound(new { error = "service_not_in_map", serviceId });
+        }
+        catch (ServiceUnavailableException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { error = "service_unavailable", message = ex.Message });
+        }
+    }
+}
+
+/// <summary>Diagnostic projection over a service map entry.</summary>
+public sealed record ServiceMapView(
+    string ServiceId,
+    string? LocalUrl,
+    string? RemoteUrlPattern,
+    bool RequiresAuth,
+    bool LocalHealthy);

--- a/src/Andy.Mcp.Gateway/Models/ResolvedRoute.cs
+++ b/src/Andy.Mcp.Gateway/Models/ResolvedRoute.cs
@@ -1,0 +1,18 @@
+namespace Andy.Mcp.Gateway.Models;
+
+/// <summary>
+/// Result of <see cref="Services.IServiceRouter.ResolveAsync"/>. Carries the
+/// chosen URL plus a tag identifying whether the routing decision picked the
+/// local or remote endpoint — useful for diagnostics and for MG4's auth
+/// bridge, which only injects a tenant JWT when <see cref="Source"/> is
+/// <see cref="RouteSource.Remote"/>.
+/// </summary>
+public sealed record ResolvedRoute(string TargetUrl, RouteSource Source);
+
+public enum RouteSource
+{
+    /// <summary>Local MCP server (Conductor LocalRuntime / Mac).</summary>
+    Local,
+    /// <summary>Remote tenant in Rivoli AI Cloud.</summary>
+    Remote,
+}

--- a/src/Andy.Mcp.Gateway/Models/ServiceMapEntry.cs
+++ b/src/Andy.Mcp.Gateway/Models/ServiceMapEntry.cs
@@ -1,0 +1,24 @@
+namespace Andy.Mcp.Gateway.Models;
+
+/// <summary>
+/// One entry in the gateway's service map. Each entry declares how to reach a
+/// given MCP-tool-providing service: a local URL (when the service is running
+/// on the same machine, e.g. via Conductor's LocalRuntime) and/or a remote URL
+/// pattern (for the cloud tenant).
+///
+/// At least one of <see cref="LocalUrl"/> and <see cref="RemoteUrlPattern"/>
+/// must be non-null. Entries with both let the router prefer-local-fallback-
+/// remote (MG1). Entries with only one are valid but degenerate.
+///
+/// <para>
+/// <see cref="RemoteUrlPattern"/> may contain a <c>{tenantSlug}</c> placeholder
+/// that MG3 substitutes at request time from the bound tenant. MG1 itself
+/// performs no substitution — it returns the pattern verbatim and lets
+/// downstream middleware fill it in.
+/// </para>
+/// </summary>
+public sealed record ServiceMapEntry(
+    string ServiceId,
+    string? LocalUrl,
+    string? RemoteUrlPattern,
+    bool RequiresAuth);

--- a/src/Andy.Mcp.Gateway/Program.cs
+++ b/src/Andy.Mcp.Gateway/Program.cs
@@ -36,6 +36,20 @@ builder.Services.AddSwaggerGen(options =>
 // Register services
 builder.Services.AddSingleton<IGatewayRegistryService, InMemoryGatewayRegistryService>();
 
+// MG1 routing core (rivoli-ai/andy-containers#241).
+// One concrete InMemoryServiceMapRegistry instance is shared by writer
+// (the file loader) and readers (the router, the health monitor, and
+// the diagnostic controller). The interface registration delegates to
+// the same instance so consumers get the same view.
+builder.Services.AddSingleton<InMemoryServiceMapRegistry>();
+builder.Services.AddSingleton<IServiceMapRegistry>(sp => sp.GetRequiredService<InMemoryServiceMapRegistry>());
+builder.Services.AddSingleton<IServiceRouter, ServiceRouter>();
+builder.Services.AddSingleton<RouteHealthMonitor>();
+builder.Services.AddSingleton<IRouteHealthMonitor>(sp => sp.GetRequiredService<RouteHealthMonitor>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<RouteHealthMonitor>());
+builder.Services.AddHttpClient("route-probe");
+builder.Services.AddHostedService<ServiceMapFileLoader>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline

--- a/src/Andy.Mcp.Gateway/Services/IRouteHealthMonitor.cs
+++ b/src/Andy.Mcp.Gateway/Services/IRouteHealthMonitor.cs
@@ -1,0 +1,19 @@
+namespace Andy.Mcp.Gateway.Services;
+
+/// <summary>
+/// Tracks the health of every entry's <c>LocalUrl</c> via periodic HTTP
+/// probes. The router consults <see cref="IsLocalHealthy"/> when picking
+/// local-or-remote.
+///
+/// Remote URLs are not probed by this monitor — remote services are assumed
+/// reachable, and failures bubble back to callers as 5xx from the proxy.
+/// </summary>
+public interface IRouteHealthMonitor
+{
+    /// <summary>
+    /// True if the most recent probe of the service's local URL succeeded.
+    /// False if the URL is missing, the probe is failing, or no probe has
+    /// completed yet.
+    /// </summary>
+    bool IsLocalHealthy(string serviceId);
+}

--- a/src/Andy.Mcp.Gateway/Services/IServiceMapRegistry.cs
+++ b/src/Andy.Mcp.Gateway/Services/IServiceMapRegistry.cs
@@ -1,0 +1,28 @@
+using Andy.Mcp.Gateway.Models;
+
+namespace Andy.Mcp.Gateway.Services;
+
+/// <summary>
+/// Read-only view of the gateway's currently-loaded service map. Backed by a
+/// YAML file on disk; hot-reloads on file change (see
+/// <see cref="ServiceMapFileLoader"/>).
+/// </summary>
+public interface IServiceMapRegistry
+{
+    /// <summary>All entries currently in the map. Snapshotted; safe to iterate.</summary>
+    IReadOnlyList<ServiceMapEntry> Entries { get; }
+
+    /// <summary>Look up a single entry by service id; returns null if absent.</summary>
+    ServiceMapEntry? Find(string serviceId);
+
+    /// <summary>
+    /// Fired whenever the underlying file is reloaded. Subscribers (notably
+    /// <see cref="IRouteHealthMonitor"/>) re-pick their probe targets.
+    /// </summary>
+    event EventHandler<ServiceMapChangedEventArgs>? Changed;
+}
+
+public sealed class ServiceMapChangedEventArgs(IReadOnlyList<ServiceMapEntry> entries) : EventArgs
+{
+    public IReadOnlyList<ServiceMapEntry> Entries { get; } = entries;
+}

--- a/src/Andy.Mcp.Gateway/Services/IServiceRouter.cs
+++ b/src/Andy.Mcp.Gateway/Services/IServiceRouter.cs
@@ -1,0 +1,28 @@
+using Andy.Mcp.Gateway.Models;
+
+namespace Andy.Mcp.Gateway.Services;
+
+/// <summary>
+/// Resolves a service id to the URL the gateway should call.
+///
+/// Policy: prefer-local-fallback-remote. If the service has a
+/// <c>LocalUrl</c> and <see cref="IRouteHealthMonitor"/> reports it healthy,
+/// the local URL wins. Otherwise the <c>RemoteUrlPattern</c> is returned (with
+/// any tenant placeholders intact — substitution lands in MG3). If neither is
+/// available, the call fails with <see cref="ServiceUnavailableException"/>.
+/// </summary>
+public interface IServiceRouter
+{
+    Task<ResolvedRoute> ResolveAsync(string serviceId, CancellationToken ct);
+}
+
+public sealed class ServiceUnavailableException : Exception
+{
+    public ServiceUnavailableException(string message) : base(message) { }
+}
+
+public sealed class ServiceNotInMapException : Exception
+{
+    public ServiceNotInMapException(string serviceId)
+        : base($"Service '{serviceId}' is not in the service map.") { }
+}

--- a/src/Andy.Mcp.Gateway/Services/InMemoryServiceMapRegistry.cs
+++ b/src/Andy.Mcp.Gateway/Services/InMemoryServiceMapRegistry.cs
@@ -1,0 +1,36 @@
+using Andy.Mcp.Gateway.Models;
+
+namespace Andy.Mcp.Gateway.Services;
+
+/// <summary>
+/// In-process holder of the service map. The file loader (see
+/// <see cref="ServiceMapFileLoader"/>) calls <see cref="Replace"/> on each
+/// successful load; <see cref="Changed"/> fires for every replacement.
+///
+/// Reads are lock-free (the field reference is swapped atomically). Writers
+/// are serialised through the registry — only the loader writes.
+/// </summary>
+public sealed class InMemoryServiceMapRegistry : IServiceMapRegistry
+{
+    private IReadOnlyList<ServiceMapEntry> _entries = Array.Empty<ServiceMapEntry>();
+    private Dictionary<string, ServiceMapEntry> _byId = new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyList<ServiceMapEntry> Entries => _entries;
+
+    public ServiceMapEntry? Find(string serviceId)
+        => _byId.TryGetValue(serviceId, out var entry) ? entry : null;
+
+    public event EventHandler<ServiceMapChangedEventArgs>? Changed;
+
+    /// <summary>
+    /// Atomically replace the entire map. Called by the file loader on
+    /// startup and on every file-change reload.
+    /// </summary>
+    public void Replace(IReadOnlyList<ServiceMapEntry> entries)
+    {
+        var index = entries.ToDictionary(e => e.ServiceId, StringComparer.OrdinalIgnoreCase);
+        _entries = entries;
+        _byId = index;
+        Changed?.Invoke(this, new ServiceMapChangedEventArgs(entries));
+    }
+}

--- a/src/Andy.Mcp.Gateway/Services/RouteHealthMonitor.cs
+++ b/src/Andy.Mcp.Gateway/Services/RouteHealthMonitor.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+using Andy.Mcp.Gateway.Models;
+
+namespace Andy.Mcp.Gateway.Services;
+
+/// <summary>
+/// Probes every <see cref="ServiceMapEntry.LocalUrl"/> on a fixed interval
+/// (default 5s) and exposes the latest result. Re-subscribes on registry
+/// changes so newly-added entries pick up probing on the next cycle.
+///
+/// Probe shape: HEAD on the URL with a 2 s timeout. Treat any 2xx-3xx as
+/// healthy. Network errors / timeouts mark unhealthy.
+/// </summary>
+public sealed class RouteHealthMonitor : BackgroundService, IRouteHealthMonitor
+{
+    private static readonly TimeSpan ProbeInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly IServiceMapRegistry _registry;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<RouteHealthMonitor> _logger;
+    private readonly ConcurrentDictionary<string, bool> _healthy = new(StringComparer.OrdinalIgnoreCase);
+
+    public RouteHealthMonitor(
+        IServiceMapRegistry registry,
+        IHttpClientFactory httpClientFactory,
+        ILogger<RouteHealthMonitor> logger)
+    {
+        _registry = registry;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public bool IsLocalHealthy(string serviceId)
+        => _healthy.TryGetValue(serviceId, out var ok) && ok;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Initial pass before the first sleep so callers don't see a
+        // window of "everything is unhealthy" right after startup.
+        await ProbeAllAsync(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(ProbeInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            await ProbeAllAsync(stoppingToken);
+        }
+    }
+
+    private async Task ProbeAllAsync(CancellationToken ct)
+    {
+        var entries = _registry.Entries;
+        // Probe in parallel; per-probe timeout caps total cycle time.
+        var tasks = entries
+            .Where(e => !string.IsNullOrEmpty(e.LocalUrl))
+            .Select(e => ProbeOneAsync(e, ct));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task ProbeOneAsync(ServiceMapEntry entry, CancellationToken ct)
+    {
+        var localUrl = entry.LocalUrl!;
+        var previous = _healthy.TryGetValue(entry.ServiceId, out var p) ? p : (bool?)null;
+
+        bool nowHealthy;
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("route-probe");
+            client.Timeout = ProbeTimeout;
+            using var req = new HttpRequestMessage(HttpMethod.Head, localUrl);
+            using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            // Any 2xx/3xx is fine — many services don't expose HEAD on their
+            // root, so a 405 still tells us the listener is up. Treat
+            // anything < 500 as healthy; 5xx means the service is broken.
+            nowHealthy = (int)resp.StatusCode < 500;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            nowHealthy = false;
+        }
+
+        _healthy[entry.ServiceId] = nowHealthy;
+
+        if (previous != nowHealthy)
+        {
+            // Structured log on every transition so on-call sees the flip
+            // without trawling for it. Log level chosen by direction:
+            // healthy → unhealthy is a warning (something just went down);
+            // unhealthy → healthy is informational (recovery).
+            if (nowHealthy)
+            {
+                _logger.LogInformation(
+                    "Local route healthy for {ServiceId} at {LocalUrl}",
+                    entry.ServiceId, localUrl);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Local route unhealthy for {ServiceId} at {LocalUrl}; falling back to remote",
+                    entry.ServiceId, localUrl);
+            }
+        }
+    }
+}

--- a/src/Andy.Mcp.Gateway/Services/ServiceMapFileLoader.cs
+++ b/src/Andy.Mcp.Gateway/Services/ServiceMapFileLoader.cs
@@ -1,0 +1,163 @@
+using Andy.Mcp.Gateway.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Andy.Mcp.Gateway.Services;
+
+/// <summary>
+/// Loads the service map from a YAML file at startup and watches for changes.
+/// On change, reloads the file; on parse error, logs and keeps the previous
+/// snapshot (better to keep stale routing than to fail closed with no map).
+///
+/// File format (see <c>servicemap.yaml</c> shipped with the binary):
+/// <code>
+/// services:
+///   - serviceId: andy-containers
+///     localUrl: https://localhost:7200
+///     remoteUrlPattern: https://containers.{tenantSlug}.rivoli.ai
+///     requiresAuth: true
+///   - serviceId: andy-agents
+///     localUrl: null
+///     remoteUrlPattern: https://agents.{tenantSlug}.rivoli.ai
+///     requiresAuth: true
+/// </code>
+/// </summary>
+public sealed class ServiceMapFileLoader : IHostedService, IDisposable
+{
+    private readonly InMemoryServiceMapRegistry _registry;
+    private readonly ILogger<ServiceMapFileLoader> _logger;
+    private readonly string _filePath;
+    private FileSystemWatcher? _watcher;
+    // Debounce noisy editors (vim writes via temp file → rename → multiple events).
+    private DateTimeOffset _lastReload = DateTimeOffset.MinValue;
+    private static readonly TimeSpan DebounceWindow = TimeSpan.FromMilliseconds(250);
+
+    public ServiceMapFileLoader(
+        InMemoryServiceMapRegistry registry,
+        IConfiguration config,
+        ILogger<ServiceMapFileLoader> logger)
+    {
+        _registry = registry;
+        _logger = logger;
+        _filePath = ResolveFilePath(config);
+    }
+
+    private static string ResolveFilePath(IConfiguration config)
+    {
+        var configured = config["ServiceMap:File"];
+        if (!string.IsNullOrEmpty(configured))
+        {
+            return Path.IsPathRooted(configured)
+                ? configured
+                : Path.Combine(AppContext.BaseDirectory, configured);
+        }
+        return Path.Combine(AppContext.BaseDirectory, "servicemap.yaml");
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        Reload();
+
+        var dir = Path.GetDirectoryName(_filePath)!;
+        var name = Path.GetFileName(_filePath);
+        _watcher = new FileSystemWatcher(dir, name)
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+        };
+        _watcher.Changed += OnFileEvent;
+        _watcher.Created += OnFileEvent;
+        _watcher.Renamed += OnFileEvent;
+        _watcher.EnableRaisingEvents = true;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _watcher?.Dispose();
+        _watcher = null;
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => _watcher?.Dispose();
+
+    private void OnFileEvent(object sender, FileSystemEventArgs e)
+    {
+        var now = DateTimeOffset.UtcNow;
+        if (now - _lastReload < DebounceWindow) return;
+        _lastReload = now;
+
+        // Brief delay so the editor has finished swapping the file in.
+        Task.Delay(50).ContinueWith(_ => Reload());
+    }
+
+    private void Reload()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                _logger.LogWarning(
+                    "Service map file {FilePath} not found; map is empty until it appears",
+                    _filePath);
+                _registry.Replace(Array.Empty<ServiceMapEntry>());
+                return;
+            }
+
+            var yaml = File.ReadAllText(_filePath);
+            var entries = ParseYaml(yaml);
+            _registry.Replace(entries);
+
+            _logger.LogInformation(
+                "Loaded {Count} service map entries from {FilePath}",
+                entries.Count, _filePath);
+        }
+        catch (Exception ex)
+        {
+            // Keep the previous snapshot on parse error. Logging the path
+            // gives the operator the file to fix; not failing closed avoids
+            // a routing outage from an unrelated edit.
+            _logger.LogError(ex,
+                "Failed to reload service map from {FilePath}; keeping previous snapshot",
+                _filePath);
+        }
+    }
+
+    private static IReadOnlyList<ServiceMapEntry> ParseYaml(string yaml)
+    {
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var doc = deserializer.Deserialize<ServiceMapFile>(yaml)
+            ?? throw new InvalidDataException("Service map file is empty.");
+
+        if (doc.Services is null) return Array.Empty<ServiceMapEntry>();
+
+        return doc.Services
+            .Where(s => !string.IsNullOrWhiteSpace(s.ServiceId))
+            .Select(s => new ServiceMapEntry(
+                ServiceId: s.ServiceId!.Trim(),
+                LocalUrl: NullIfBlank(s.LocalUrl),
+                RemoteUrlPattern: NullIfBlank(s.RemoteUrlPattern),
+                RequiresAuth: s.RequiresAuth))
+            .ToList();
+    }
+
+    private static string? NullIfBlank(string? s)
+        => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+
+    /// <summary>YAML-side mutable shape; YamlDotNet doesn't bind to records.</summary>
+    private sealed class ServiceMapFile
+    {
+        public List<ServiceMapEntryYaml>? Services { get; set; }
+    }
+
+    private sealed class ServiceMapEntryYaml
+    {
+        public string? ServiceId { get; set; }
+        public string? LocalUrl { get; set; }
+        public string? RemoteUrlPattern { get; set; }
+        public bool RequiresAuth { get; set; }
+    }
+}

--- a/src/Andy.Mcp.Gateway/Services/ServiceRouter.cs
+++ b/src/Andy.Mcp.Gateway/Services/ServiceRouter.cs
@@ -1,0 +1,37 @@
+using Andy.Mcp.Gateway.Models;
+
+namespace Andy.Mcp.Gateway.Services;
+
+/// <inheritdoc cref="IServiceRouter"/>
+public sealed class ServiceRouter : IServiceRouter
+{
+    private readonly IServiceMapRegistry _registry;
+    private readonly IRouteHealthMonitor _health;
+
+    public ServiceRouter(IServiceMapRegistry registry, IRouteHealthMonitor health)
+    {
+        _registry = registry;
+        _health = health;
+    }
+
+    public Task<ResolvedRoute> ResolveAsync(string serviceId, CancellationToken ct)
+    {
+        var entry = _registry.Find(serviceId)
+            ?? throw new ServiceNotInMapException(serviceId);
+
+        // Local takes precedence — only when both URL is present AND health
+        // monitor reports the listener responding.
+        if (!string.IsNullOrEmpty(entry.LocalUrl) && _health.IsLocalHealthy(entry.ServiceId))
+        {
+            return Task.FromResult(new ResolvedRoute(entry.LocalUrl, RouteSource.Local));
+        }
+
+        if (!string.IsNullOrEmpty(entry.RemoteUrlPattern))
+        {
+            return Task.FromResult(new ResolvedRoute(entry.RemoteUrlPattern, RouteSource.Remote));
+        }
+
+        throw new ServiceUnavailableException(
+            $"Service '{serviceId}' has no healthy local route and no remote URL pattern.");
+    }
+}

--- a/src/Andy.Mcp.Gateway/servicemap.yaml
+++ b/src/Andy.Mcp.Gateway/servicemap.yaml
@@ -1,0 +1,48 @@
+# Default service map shipped with the gateway. Conductor overlays this at
+# runtime via the LocalRuntime contract (MG5). Editable in place — the
+# gateway hot-reloads on file change.
+#
+# Each entry declares one MCP-tool-providing service:
+#
+#   serviceId          stable identifier; clients address this name
+#   localUrl           reachable when running on the dev's Mac (or any
+#                      same-host LocalRuntime). Null = cloud-only service.
+#   remoteUrlPattern   tenant-aware URL with {tenantSlug} placeholder; MG3
+#                      substitutes the bound tenant at request time
+#   requiresAuth       true when the service expects a tenant JWT (MG4)
+#
+# Routing policy: prefer-local-fallback-remote per service. The health
+# monitor probes localUrl every 5 s; on failure the router falls back to
+# remoteUrlPattern with structured logs on every transition.
+
+services:
+  - serviceId: andy-containers
+    localUrl: https://localhost:7200
+    remoteUrlPattern: https://containers.{tenantSlug}.rivoli.ai
+    requiresAuth: true
+
+  - serviceId: andy-auth
+    localUrl: https://localhost:5001
+    remoteUrlPattern: https://auth.{tenantSlug}.rivoli.ai
+    requiresAuth: false
+
+  - serviceId: andy-rbac
+    localUrl: https://localhost:5003
+    remoteUrlPattern: https://rbac.{tenantSlug}.rivoli.ai
+    requiresAuth: true
+
+  - serviceId: andy-settings
+    localUrl: https://localhost:5300
+    remoteUrlPattern: https://settings.{tenantSlug}.rivoli.ai
+    requiresAuth: true
+
+  - serviceId: andy-tenants
+    localUrl: https://localhost:5005
+    remoteUrlPattern: https://tenants.rivoli.ai
+    requiresAuth: true
+
+  # Cloud-only — no local equivalent today. Routes always go remote.
+  - serviceId: andy-agents
+    localUrl: null
+    remoteUrlPattern: https://agents.{tenantSlug}.rivoli.ai
+    requiresAuth: true

--- a/tests/Andy.Mcp.Gateway.Tests/Services/ServiceMapFileLoaderTests.cs
+++ b/tests/Andy.Mcp.Gateway.Tests/Services/ServiceMapFileLoaderTests.cs
@@ -1,0 +1,141 @@
+using Andy.Mcp.Gateway.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Andy.Mcp.Gateway.Tests.Services;
+
+/// <summary>
+/// Loader tests use a temporary file per case so they don't conflict in
+/// parallel runs. Hot-reload assertion uses Task.Delay to wait out the
+/// debounce window — short and bounded.
+/// </summary>
+public sealed class ServiceMapFileLoaderTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ServiceMapFileLoaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "mg1-loader-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private (ServiceMapFileLoader loader, InMemoryServiceMapRegistry registry, string filePath)
+        BuildLoader(string yamlContent)
+    {
+        var filePath = Path.Combine(_tempDir, "servicemap.yaml");
+        File.WriteAllText(filePath, yamlContent);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ServiceMap:File"] = filePath,
+            })
+            .Build();
+
+        var registry = new InMemoryServiceMapRegistry();
+        var loader = new ServiceMapFileLoader(registry, config, NullLogger<ServiceMapFileLoader>.Instance);
+        return (loader, registry, filePath);
+    }
+
+    [Fact]
+    public async Task StartAsync_LoadsValidYaml()
+    {
+        var (loader, registry, _) = BuildLoader(
+            """
+            services:
+              - serviceId: svc-a
+                localUrl: https://localhost:1111
+                remoteUrlPattern: https://svc-a.{tenantSlug}.rivoli.ai
+                requiresAuth: true
+              - serviceId: cloud-only
+                localUrl: null
+                remoteUrlPattern: https://cloud.example.com
+                requiresAuth: false
+            """);
+
+        await loader.StartAsync(CancellationToken.None);
+
+        Assert.Equal(2, registry.Entries.Count);
+        var svcA = registry.Find("svc-a")!;
+        Assert.Equal("https://localhost:1111", svcA.LocalUrl);
+        Assert.True(svcA.RequiresAuth);
+        var cloudOnly = registry.Find("cloud-only")!;
+        Assert.Null(cloudOnly.LocalUrl);
+        Assert.False(cloudOnly.RequiresAuth);
+
+        await loader.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_TreatsBlankLocalUrlAsNull()
+    {
+        var (loader, registry, _) = BuildLoader(
+            """
+            services:
+              - serviceId: svc
+                localUrl: "   "
+                remoteUrlPattern: https://x
+                requiresAuth: false
+            """);
+
+        await loader.StartAsync(CancellationToken.None);
+
+        Assert.Null(registry.Find("svc")!.LocalUrl);
+
+        await loader.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_KeepsPreviousSnapshot_OnInvalidYaml()
+    {
+        var (loader, registry, filePath) = BuildLoader(
+            """
+            services:
+              - serviceId: good
+                localUrl: http://l
+                remoteUrlPattern: http://r
+                requiresAuth: true
+            """);
+
+        await loader.StartAsync(CancellationToken.None);
+        Assert.Single(registry.Entries);
+
+        // Overwrite with invalid YAML and trigger a reload by waiting for
+        // the watcher. The loader should log + skip; previous snapshot stays.
+        File.WriteAllText(filePath, "this: is: not: valid: yaml: [");
+        await Task.Delay(500); // debounce + watcher event
+
+        // Either the registry kept the original or got cleared. Loader's
+        // contract is "keep previous on parse error", so we expect the
+        // original entry to still be there.
+        Assert.Single(registry.Entries);
+        Assert.Equal("good", registry.Entries[0].ServiceId);
+
+        await loader.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyMapWhenFileMissing()
+    {
+        var filePath = Path.Combine(_tempDir, "missing.yaml");
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ServiceMap:File"] = filePath,
+            })
+            .Build();
+        var registry = new InMemoryServiceMapRegistry();
+        var loader = new ServiceMapFileLoader(registry, config, NullLogger<ServiceMapFileLoader>.Instance);
+
+        await loader.StartAsync(CancellationToken.None);
+
+        Assert.Empty(registry.Entries);
+
+        await loader.StopAsync(CancellationToken.None);
+    }
+}

--- a/tests/Andy.Mcp.Gateway.Tests/Services/ServiceMapRegistryTests.cs
+++ b/tests/Andy.Mcp.Gateway.Tests/Services/ServiceMapRegistryTests.cs
@@ -1,0 +1,55 @@
+using Andy.Mcp.Gateway.Models;
+using Andy.Mcp.Gateway.Services;
+
+namespace Andy.Mcp.Gateway.Tests.Services;
+
+public sealed class InMemoryServiceMapRegistryTests
+{
+    [Fact]
+    public void Find_IsCaseInsensitive()
+    {
+        var registry = new InMemoryServiceMapRegistry();
+        registry.Replace(new[]
+        {
+            new ServiceMapEntry("Andy-Containers", "http://local", "http://remote", true),
+        });
+
+        Assert.NotNull(registry.Find("andy-containers"));
+        Assert.NotNull(registry.Find("ANDY-CONTAINERS"));
+        Assert.Null(registry.Find("missing"));
+    }
+
+    [Fact]
+    public void Replace_FiresChangedEvent()
+    {
+        var registry = new InMemoryServiceMapRegistry();
+        IReadOnlyList<ServiceMapEntry>? observed = null;
+        registry.Changed += (_, e) => observed = e.Entries;
+
+        var entries = new[]
+        {
+            new ServiceMapEntry("svc", "http://l", null, false),
+        };
+        registry.Replace(entries);
+
+        Assert.NotNull(observed);
+        Assert.Single(observed!);
+    }
+
+    [Fact]
+    public void Replace_AtomicallySwapsSnapshot()
+    {
+        // Reads against an old snapshot must stay consistent even when a
+        // writer races with a Replace. Capture two snapshots and assert
+        // they're independently iterable.
+        var registry = new InMemoryServiceMapRegistry();
+        registry.Replace(new[] { new ServiceMapEntry("a", "http://1", null, false) });
+        var snapshotA = registry.Entries;
+
+        registry.Replace(new[] { new ServiceMapEntry("b", "http://2", null, false) });
+        var snapshotB = registry.Entries;
+
+        Assert.Equal("a", snapshotA[0].ServiceId);
+        Assert.Equal("b", snapshotB[0].ServiceId);
+    }
+}

--- a/tests/Andy.Mcp.Gateway.Tests/Services/ServiceRouterTests.cs
+++ b/tests/Andy.Mcp.Gateway.Tests/Services/ServiceRouterTests.cs
@@ -1,0 +1,102 @@
+using Andy.Mcp.Gateway.Models;
+using Andy.Mcp.Gateway.Services;
+
+namespace Andy.Mcp.Gateway.Tests.Services;
+
+public sealed class ServiceRouterTests
+{
+    private readonly InMemoryServiceMapRegistry _registry = new();
+    private readonly StubHealthMonitor _health = new();
+
+    private IServiceRouter NewRouter() => new ServiceRouter(_registry, _health);
+
+    [Fact]
+    public async Task ResolveAsync_PrefersLocal_WhenLocalUrlSetAndHealthy()
+    {
+        _registry.Replace(new[]
+        {
+            new ServiceMapEntry("svc-a", "https://localhost:1111", "https://remote.example", true),
+        });
+        _health.MarkHealthy("svc-a");
+
+        var route = await NewRouter().ResolveAsync("svc-a", CancellationToken.None);
+
+        Assert.Equal(RouteSource.Local, route.Source);
+        Assert.Equal("https://localhost:1111", route.TargetUrl);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FallsBackToRemote_WhenLocalUnhealthy()
+    {
+        _registry.Replace(new[]
+        {
+            new ServiceMapEntry("svc-a", "https://localhost:1111", "https://remote.example", true),
+        });
+        // No MarkHealthy → defaults to unhealthy.
+
+        var route = await NewRouter().ResolveAsync("svc-a", CancellationToken.None);
+
+        Assert.Equal(RouteSource.Remote, route.Source);
+        Assert.Equal("https://remote.example", route.TargetUrl);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FallsBackToRemote_WhenLocalUrlMissing()
+    {
+        _registry.Replace(new[]
+        {
+            new ServiceMapEntry("cloud-only", null, "https://remote.example", true),
+        });
+        // Health monitor is irrelevant here — there's no local URL to probe.
+
+        var route = await NewRouter().ResolveAsync("cloud-only", CancellationToken.None);
+
+        Assert.Equal(RouteSource.Remote, route.Source);
+        Assert.Equal("https://remote.example", route.TargetUrl);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PreservesTenantPlaceholder()
+    {
+        // MG1 returns the remote pattern verbatim; MG3 will substitute
+        // {tenantSlug} from the bound tenant. This test pins that contract.
+        _registry.Replace(new[]
+        {
+            new ServiceMapEntry("svc-a", null, "https://svc-a.{tenantSlug}.rivoli.ai", true),
+        });
+
+        var route = await NewRouter().ResolveAsync("svc-a", CancellationToken.None);
+
+        Assert.Equal(RouteSource.Remote, route.Source);
+        Assert.Contains("{tenantSlug}", route.TargetUrl);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Throws_WhenNeitherLocalNorRemoteAvailable()
+    {
+        _registry.Replace(new[]
+        {
+            new ServiceMapEntry("local-only", "https://localhost:9999", null, true),
+        });
+        // Local missing AND no remote → service unavailable.
+
+        await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => NewRouter().ResolveAsync("local-only", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Throws_WhenServiceNotInMap()
+    {
+        _registry.Replace(Array.Empty<ServiceMapEntry>());
+
+        await Assert.ThrowsAsync<ServiceNotInMapException>(
+            () => NewRouter().ResolveAsync("nope", CancellationToken.None));
+    }
+
+    private sealed class StubHealthMonitor : IRouteHealthMonitor
+    {
+        private readonly HashSet<string> _healthy = new(StringComparer.OrdinalIgnoreCase);
+        public void MarkHealthy(string serviceId) => _healthy.Add(serviceId);
+        public bool IsLocalHealthy(string serviceId) => _healthy.Contains(serviceId);
+    }
+}


### PR DESCRIPTION
Implements rivoli-ai/andy-containers#241 (cross-repo issue tracked there).

First story in rivoli-ai/andy-containers#224 (Epic MG — andy-mcp-gateway local/remote routing).

## Summary

- New types: `ServiceMapEntry`, `ResolvedRoute`, `RouteSource`
- `IServiceMapRegistry` / `InMemoryServiceMapRegistry` — atomic-snapshot store with change events
- `IServiceRouter` / `ServiceRouter` — prefer-local-fallback-remote, preserves `{tenantSlug}` placeholder for MG3
- `IRouteHealthMonitor` / `RouteHealthMonitor` — BackgroundService, HEAD-probes local URLs every 5 s with 2 s timeout, structured log on every transition
- `ServiceMapFileLoader` — YAML loader + FileSystemWatcher hot-reload; keeps previous snapshot on parse error rather than failing closed
- `RoutingController` — diagnostic surface (`GET /api/routing/services` and `GET /api/routing/resolve/{serviceId}`)
- `servicemap.yaml` shipped with the binary covering andy-containers, andy-auth, andy-rbac, andy-settings, andy-tenants, andy-agents

## Repo conventions

- Adds `global.json` pinning .NET 9 with rollForward `latestMajor`. The repo currently has no `global.json` and inherits whatever the parent directory specifies — fragile. Fixed.
- New package dep: `YamlDotNet 16.2.0` (only).

## Test plan

- [x] 13 new tests; full suite 35/35 green (`dotnet test`)
- [x] `dotnet build` clean (0 warnings)
- [x] Routing decision unit tests cover: local-healthy → local; local-unhealthy → remote; cloud-only → remote; placeholder preserved; both-missing → 503; not-in-map → 404
- [x] Loader tests cover: valid YAML; blank URL → null; invalid YAML keeps previous snapshot; missing file → empty map
- [x] Registry tests cover: case-insensitive lookup; change event; atomic-snapshot semantics

## Out of scope (later MG stories)

- Heartbeat-based discovery (MG2 #238)
- Tenant binding + URL substitution (MG3 #240)
- Auth bridge (MG4 #243)
- Conductor LocalRuntime contract (MG5 #239)

🤖 Generated with [Claude Code](https://claude.com/claude-code)