### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This file contains authorized commands and configuration for Claude Code Assista
 
 ### Platform-Specific Notes (macOS)
 
-- **NEVER use mono or .exe files** - This is a .NET 8.0 project running natively on macOS
+- **NEVER use mono or .exe files** - This is a .NET 9.0 project running natively on macOS
 - **Use `dotnet run`** instead of compiling to .exe and running with mono
 - **Use `dotnet <command>`** for all .NET operations (build, test, run, etc.)
 
@@ -32,7 +32,7 @@ This file contains authorized commands and configuration for Claude Code Assista
 
 ## Project Information
 
-- **Target Framework**: .NET 8.0
+- **Target Framework**: .NET 9.0
 - **Test Framework**: xUnit
 - **Coverage Tool**: Coverlet
 - **Report Generator**: ReportGenerator global tool
@@ -55,7 +55,6 @@ When completing a set of tasks or phase milestones:
 
 - Always write test in the tests/ assemblies for new code or code changes in the src/ directory
 - Run `dotnet format` before committing to ensure consistent formatting
-- Use the pre-commit hooks: `./scripts/setup-git-hooks.sh` (Linux/macOS) or `./scripts/setup-git-hooks.ps1` (Windows)
 - Ensure all tests pass: `dotnet test`
 - Generate coverage reports for significant changes
 
@@ -74,46 +73,6 @@ When completing a set of tasks or phase milestones:
 - Keep README.md current with latest .NET version and features
 - Update local development setup guide when adding new tools or processes
 - Maintain conversion plan progress tracking for transparency
-
-## Rendering System Architecture Issues
-
-### Current Problems (2025-08-11)
-
-The rendering system has fundamental architectural problems that cause erratic output:
-
-1. **Dual Rendering Approaches**: VirtualDomRenderer uses both:
-   - `RenderElement` method for positioning and z-ordering
-   - Visitor pattern (`Accept(this)`) for node-specific rendering
-   - These approaches conflict, causing double-rendering and positioning issues
-
-2. **Inconsistent Node Handling**:
-   - FragmentNode: Special handling in `RenderElement` but empty `VisitFragment`
-   - ClippingNode: Complex setup in `VisitClipping` but also processed by normal flow
-   - TextNode: Only handled via visitor pattern
-   - ElementNode: Handled by both approaches
-
-3. **API Inconsistency**:
-   - Some components use `Children.Add()` (not possible - readonly)
-   - Others use `AddChild()` method  
-   - Collection initializer syntax conflicts with fluent methods
-
-### Required Fixes
-
-1. **Unify Rendering**: Choose ONE approach - either visitor OR element-based
-2. **Fix Node Processing**: Each node type should have ONE clear rendering path
-3. **Consistent APIs**: All components should use same pattern for adding children
-4. **Proper Clipping**: Implement clipping in the unified rendering approach
-
-### Detailed Rendering Diagnostics
-
-The comprehensive logging system captures:
-- Layout calculations and constraints
-- Virtual DOM tree construction and diffing  
-- Rendering operations and positioning
-- Focus management and state changes
-- Performance metrics and timing
-
-Use `ComprehensiveLoggingInitializer.Initialize(isTestMode: true)` in tests to enable detailed rendering logs for debugging.
 
 ## Notes
 

--- a/agents.md
+++ b/agents.md
@@ -18,7 +18,7 @@ This file contains authorized commands and configuration for Claude Code Assista
 
 ### Platform-Specific Notes (macOS)
 
-- **NEVER use mono or .exe files** - This is a .NET 8.0 project running natively on macOS
+- **NEVER use mono or .exe files** - This is a .NET 9.0 project running natively on macOS
 - **Use `dotnet run`** instead of compiling to .exe and running with mono
 - **Use `dotnet <command>`** for all .NET operations (build, test, run, etc.)
 
@@ -32,7 +32,7 @@ This file contains authorized commands and configuration for Claude Code Assista
 
 ## Project Information
 
-- **Target Framework**: .NET 8.0
+- **Target Framework**: .NET 9.0
 - **Test Framework**: xUnit
 - **Coverage Tool**: Coverlet
 - **Report Generator**: ReportGenerator global tool
@@ -55,7 +55,6 @@ When completing a set of tasks or phase milestones:
 
 - Always write test in the tests/ assemblies for new code or code changes in the src/ directory
 - Run `dotnet format` before committing to ensure consistent formatting
-- Use the pre-commit hooks: `./scripts/setup-git-hooks.sh` (Linux/macOS) or `./scripts/setup-git-hooks.ps1` (Windows)
 - Ensure all tests pass: `dotnet test`
 - Generate coverage reports for significant changes
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` / `agents.md`: corrected the documented target framework from `.NET 8.0` to `.NET 9.0` (matches `src/Andy.Mcp.Gateway.csproj`, `tests/Andy.Mcp.Gateway.Tests.csproj`, `examples/Andy.Mcp.Gateway.Examples.csproj`, and the README).
- Removed the broken `./scripts/setup-git-hooks.sh` reference — no `scripts/` folder exists.
- `CLAUDE.md`: removed the "Rendering System Architecture Issues" section — it referenced `VirtualDomRenderer`, `FragmentNode`, `ClippingNode`, `ComprehensiveLoggingInitializer` and other types that do not exist in this repo.

No prose/style/license/changelog changes.